### PR TITLE
Removes wait for app boot for routes registration

### DIFF
--- a/src/GridSortableServiceProvider.php
+++ b/src/GridSortableServiceProvider.php
@@ -23,9 +23,7 @@ class GridSortableServiceProvider extends ServiceProvider
             );
         }
 
-        $this->app->booted(function () {
-            GridSortable::routes(__DIR__.'/../routes/web.php');
-        });
+        GridSortable::routes(__DIR__.'/../routes/web.php');
 
         Admin::booting(function () {
             Admin::headerJs('vendor/laravel-admin-ext/grid-sortable/jquery-ui.min.js');


### PR DESCRIPTION
Waiting for app to boot causes the routes to register late, at the end of the routes list.
May cause overriding of user defined routes.
Or in my case, a "catch all" route which caught the `_grid-sortable_` route (because it was prior in the routes list).