### PR TITLE
Multi sortable grid in single page supported!

### DIFF
--- a/src/SaveOrderBtn.php
+++ b/src/SaveOrderBtn.php
@@ -15,10 +15,12 @@ class SaveOrderBtn extends AbstractTool
 
         $class = str_replace('\\', '\\\\', $class);
 
+        $name = $this->getButtonId();
+
         $script = <<<SCRIPT
 (function () {
     
-    $('.grid-save-order-btn').click(function () {
+    $('#{$name}').click(function () {
 
         $.post('{$route}', {
             _token: $.admin.token,
@@ -45,12 +47,19 @@ SCRIPT;
     {
         $this->script();
 
+        $name = $this->getButtonId();
+
         $text = __('Save order');
 
         return <<<HTML
-<button type="button" class="btn btn-sm btn-info grid-save-order-btn" style="margin-left: 10px;display: none;">
+<button id={$name} type="button" class="btn btn-sm btn-info grid-save-order-btn" style="margin-left: 10px;display: none;">
     <i class="fa fa-save"></i><span class="hidden-xs">&nbsp;&nbsp;{$text}</span>
 </button>
 HTML;
+    }
+
+    private function getButtonId()
+    {
+        return $this->getGrid()->getName() ?: 'grid-save-order-btn';
     }
 }


### PR DESCRIPTION
#### What‘s New?

使用ID Selector替代了SaveOrderBtn中的Class Selector

#### Why?

当需要在一个Form中添加多个Sortable Grid时， 由于之前使用Class Selector导致点击’Save Order‘后触发重复提交。现在使用Grid Name区分不同按钮，如果一个页面中只存在一个Sortable Grid则用法保持不变，存在多个Sortable Grid时通过$grid->setName('xxx');提供标识从而避免重复提交